### PR TITLE
fUBI mint modified to call _safeMint passing the custom data as param

### DIFF
--- a/contracts/fUBI.sol
+++ b/contracts/fUBI.sol
@@ -157,7 +157,7 @@ contract fUBI is ERC721, IFUBI, ReentrancyGuard  {
 
       FlowIdsOf[sender].push(lastTokenId);
 
-      _safeMint(recipient, lastTokenId);
+      _safeMint(recipient, lastTokenId, data);
 
       ubiOutflow[sender] = ubiOutflow[sender].add(ubiPerSecond);
       ubiInflow[recipient] = ubiInflow[recipient].add(ubiPerSecond); 


### PR DESCRIPTION
This is needed for the `onERC721Received` hook on the Bridge and might be useful for other possible future integrations